### PR TITLE
Update names of settings in Discourse Admin pannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Discourse sites), `DiscourseSsoConsumer` has no other dependencies.
 The complete set of configuration parameters is listed below.  At a
 minimum, you will need to set the `SsoProviderUrl` and `SharedSecret`
 parameters, in concert with the Discourse site.  (On the Discourse site,
-you will need to set `enable sso provider` and `sso provider secrets` under
-`Admin -> Settings -> Login`.)
+you will need to set `enable discourse connect provider` and `discourse
+connect provider secrets` under `Admin -> Settings -> Login`.)
 
 As mentioned in the `PluggableAuth` documentation, you will likely want to
 configure the MediaWiki permissions to allow extensions to automatically
@@ -72,7 +72,7 @@ in particular:
  * `$wgDiscourseSsoConsumer_SharedSecret`
    * *mandatory string - no default value*
    * Specifies the secret shared with the Discourse server, via its
-     `sso provider secrets` setting.
+     `discourse connect provider secrets` setting.
 
  * `$wgDiscourseSsoConsumer_LinkExistingBy`
    * default value: `[ ]` (empty array)


### PR DESCRIPTION
Discourse SSO is called DiscourseConnect as of February 2021. ([See here for details.](https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045))

The names of some of the fields in Discourse's Admin panel have changed as a result:

![image](https://user-images.githubusercontent.com/442741/125136073-fcf40700-e101-11eb-8f9d-ae265a7d7e84.png)

 I've updated the README.md to reflect that.