### PR TITLE
Set 'name' to the empty string if Discourse didn't set it.

### DIFF
--- a/src/DiscourseSsoConsumer.php
+++ b/src/DiscourseSsoConsumer.php
@@ -584,13 +584,16 @@ class DiscourseSsoConsumer extends PluggableAuth {
     $parsed = [];
     parse_str( $decoded, $parsed );
 
+    // NB: 'name' can be missing from the response if it was never set
+    // in Discourse; e.g., this can happen for Discourse users created
+    // by import from another forum.
     $response = [
       'nonce' => $parsed['nonce'],
       'return_sso_url' => $parsed['return_sso_url'],
       'credentials' => [
         'external_id' => (int)$parsed['external_id'],
         'username' => $parsed['username'],
-        'name' => $parsed['name'],
+        'name' => $parsed['name'] ?? '',
         'email' => $parsed['email'],
         'groups' => explode( ',', $parsed['groups'] ),
         'is_admin' => ( $parsed['admin'] === 'true' ) ? true : false,


### PR DESCRIPTION
It's possible that Discourse doesn't include the `name` field in the auth response.

From the MW log:
```
[DiscourseSsoConsumer] Received response: 'admin=false&moderator=false&email=uckelman%40gmail.com&external_id=12612&groups=trust_level_0%2Ctrust_level_1&logout=false&nonce=3432ba714cdf3a876af2eb7bbe87174bef8c47a864293de91b96cf09bd85a4993b8a7a06738aac48f74ed3fb72215fce9ee7896fd423b65103b0fc53a001af7a&return_sso_url=https%3A%2F%2Fwww.test.vassalengine.org%2Fwiki%2FSpecial%3APluggableAuthLogin&username=test5678'
[error] [YOjPd99Em4l8bIspMYsQYwAAANE] /wiki/Special:PluggableAuthLogin?sso=YWRtaW49ZmFsc2UmbW9kZXJhdG9yPWZhbHNlJmVtYWlsPXVja2VsbWFuJTQwZ21haWwuY29tJmV4dGVybmFsX2lkPTEyNjEyJmdyb3Vwcz10cnVzdF9sZXZlbF8wJTJDdHJ1c3RfbGV2ZWxfMSZsb2dvdXQ9ZmFsc2Umbm9uY2U9MzQzMmJhNzE0Y2RmM2E4NzZhZjJlYjdiYmU4NzE3NGJlZjhjNDdhODY0MjkzZGU5MWI5NmNmMDliZDg1YTQ5OTNiOGE3YTA2NzM4YWFjNDhmNzRlZDNmYjcyMjE1ZmNlOWVlNzg5NmZkNDIzYjY1MTAzYjBmYzUzYTAwMWFmN2EmcmV0dXJuX3Nzb191cmw9aHR0cHMlM0ElMkYlMkZ3d3cudGVzdC52YXNzYWxlbmdpbmUub3JnJTJGd2lraSUyRlNwZWNpYWwlM0FQbHVnZ2FibGVBdXRoTG9naW4mdXNlcm5hbWU9dGVzdDU2Nzg%3D&sig=eab7462c2235a4a0efb6c29cc6b7c50f31506d382c2a85ae4f1fbca4f8443f82 ErrorException from line 593 of /usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/DiscourseSsoConsumer.php: PHP Notice: Undefined index: name
[DiscourseSsoConsumer] Received credentials: array (
'external_id' => 12612,
'username' => 'test5678',
'name' => NULL,
'email' => 'uckelman@gmail.com',
'groups' =>
array (
0 => 'trust_level_0',
1 => 'trust_level_1',
),
'is_admin' => false,
'is_moderator' => false,
)
```

And then this causes the following exception later:
```
TypeError from line 858 of /usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/DiscourseSsoConsumer.php: Argument 1 passed to MediaWiki\Extension\DiscourseSsoConsumer\DiscourseSsoConsumer::wikifyName() must be of the type string, null given, called in /usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/DiscourseSsoConsumer.php on line 467

Backtrace:

#0 /usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/DiscourseSsoConsumer.php(467): MediaWiki\Extension\DiscourseSsoConsumer\DiscourseSsoConsumer->wikifyName()
#1 /usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/DiscourseSsoConsumer.php(405): MediaWiki\Extension\DiscourseSsoConsumer\DiscourseSsoConsumer->handleUnknownUser()
#2 /usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/DiscourseSsoConsumer.php(113): MediaWiki\Extension\DiscourseSsoConsumer\DiscourseSsoConsumer->completeAuthentication()
#3 /usr/share/mediawiki/extensions/PluggableAuth/includes/PluggableAuthLogin.php(36): MediaWiki\Extension\DiscourseSsoConsumer\DiscourseSsoConsumer->authenticate()
#4 /usr/share/mediawiki/includes/specialpage/SpecialPage.php(600): PluggableAuthLogin->execute()
#5 /usr/share/mediawiki/includes/specialpage/SpecialPageFactory.php(635): SpecialPage->run()
#6 /usr/share/mediawiki/includes/MediaWiki.php(307): MediaWiki\SpecialPage\SpecialPageFactory->executePath()
#7 /usr/share/mediawiki/includes/MediaWiki.php(940): MediaWiki->performRequest()
#8 /usr/share/mediawiki/includes/MediaWiki.php(543): MediaWiki->main()
#9 /usr/share/mediawiki/index.php(53): MediaWiki->run()
#10 /usr/share/mediawiki/index.php(46): wfIndexMain()
#11 {main}
```

Discoruse can fail to send a `name` if you have users in Discoruse imported from another forum (phpBB in my case) where the users never set a real name. (There might be othe ways, but this way is the one I hit myself.)

This PR fixes the bug by setting `name` to an empty string if it wasn't sent.