### PR TITLE
Adjusted INSERT INTO to prevent mysql from complaining that the same table is the source and target

### DIFF
--- a/sql/patch-v0002.sql
+++ b/sql/patch-v0002.sql
@@ -21,9 +21,9 @@
 
 -- Ensure we are at v0001 (if not, fail with NOT NULL constraint violation).
 INSERT INTO /*_*/discourse_sso_consumer_meta (m_key, m_value)
-  VALUES ( 'CheckForCorrectStartingVersion',
+  SELECT 'CheckForCorrectStartingVersion',
            (SELECT m_value FROM /*_*/discourse_sso_consumer_meta
-              WHERE m_key = 'schemaVersion' AND m_value = '1') );
+              WHERE m_key = 'schemaVersion' AND m_value = '1');
 DELETE FROM /*_*/discourse_sso_consumer_meta
   WHERE m_key = 'CheckForCorrectStartingVersion';
 

--- a/sql/patch-v0003.sql
+++ b/sql/patch-v0003.sql
@@ -21,8 +21,8 @@
 
 -- Ensure we are at v0002 (if not, fail with NOT NULL constraint violation).
 INSERT INTO /*_*/discourse_sso_consumer_meta (m_key, m_value)
-  VALUES ( 'precheck', (SELECT m_value FROM /*_*/discourse_sso_consumer_meta
-                        WHERE m_key = 'schemaVersion' AND m_value = '2') );
+  SELECT 'precheck', (SELECT m_value FROM /*_*/discourse_sso_consumer_meta
+                        WHERE m_key = 'schemaVersion' AND m_value = '2');
 DELETE FROM /*_*/discourse_sso_consumer_meta WHERE m_key = 'precheck';
 
 


### PR DESCRIPTION
When I tried upgrading to 2.0.0, I got the following error on running `update.php`:
```
Patching DiscourseSsoConsumer schema to v0002 via '/usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/../sql/patch-v0002.sql' ...Wikimedia\Rdbms\DBQueryError from line 1699 of /usr/share/mediawiki/includes/libs/rdbms/database/Database.php: Error 1093: Table 'discourse_sso_consumer_meta' is specified twice, both as a target for 'INSERT' and as a separate source for data (localhost)
Function: Wikimedia\Rdbms\Database::sourceFile( /usr/share/mediawiki/extensions/DiscourseSsoConsumer/src/../sql/patch-v0002.sql )
Query: INSERT INTO `discourse_sso_consumer_meta` (m_key, m_value)
 VALUES ( 'CheckForCorrectStartingVersion',
 (SELECT m_value FROM `discourse_sso_consumer_meta`
 WHERE m_key = 'schemaVersion' AND m_value = '1') )
```
mysql apparently doesn't like having an `INSERT` and its immediate subquery be on the same table. This patch introduces an intermediate `SELECT`, which satisfies mysql.