### PR TITLE
Fixed TypeError: str_replace wants strings, externalId is in int.

### DIFF
--- a/src/DiscourseSsoConsumer.php
+++ b/src/DiscourseSsoConsumer.php
@@ -1214,7 +1214,7 @@ class DiscourseSsoConsumer extends PluggableAuth {
    */
   private function logoutFromDiscourse( int $externalId ): void {
     $fullLogoutUrl = $this->config->get( 'DiscourseUrl' ) .
-                   str_replace( '{id}', $externalId,
+                   str_replace( '{id}', (string) $externalId,
                                 $this->config->get( 'LogoutApiEndpoint' ) );
 
     $options = [


### PR DESCRIPTION
I found a bug that causes a `TypeError` on logout just now. This fixes the problem.